### PR TITLE
Ensure fits.sh is executable.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,6 +25,12 @@
   become: true
   ignore_errors: '{{ ansible_check_mode }}'
 
+- name: Ensure fits is executable
+  file:
+    path: '{{ fits_install }}/fits-{{ fits_version }}/fits.sh'
+    state: file
+    mode: "0755"
+
 - name: Disable Tika
   lineinfile:
     dest='{{ fits_install }}/fits-{{ fits_version }}/xml/fits.xml'


### PR DESCRIPTION
Some older versions of FITS don't set this up for you.